### PR TITLE
Docker part Deux: Avoid npm in production with Docker

### DIFF
--- a/index.html
+++ b/index.html
@@ -253,8 +253,8 @@
             To add yourself to this slot, change the following two lines
             and add a short description paragraph in the pull request.
           -->
-          <small>Listen to our first speaker, or better yet</small>
-          <div><a href="https://github.com/brooklynjs/brooklynjs.github.io/edit/master/index.html">BE OUR FIRST SPEAKER</a></div>
+          <small>HIGHLY CONTROVERSIAL: Avoid npm in production by packaging apps as tarballs using Docker (aka. Docker part Deux).</small>
+          <div><a href="https://twitter.com/frazelledazzell">Jessie Frazelle</a></div>
         </li>
         <li class="ride"></li>
         <li class="speaker">


### PR DESCRIPTION
Avoid npm in production by packaging apps as tarballs using Docker (aka. Docker part Deux).
