### PR TITLE
Talk proposal for May 21 (mongo-views)

### DIFF
--- a/index.html
+++ b/index.html
@@ -249,12 +249,9 @@
         <li class="ride"></li>
         <li class="speaker">
           <time><script>speakerTime()</script></time>
-          <!--
-            To add yourself to this slot, change the following two lines
-            and add a short description paragraph in the pull request.
-          -->
-          <small>Listen to our first speaker, or better yet</small>
-          <div><a href="https://github.com/brooklynjs/brooklynjs.github.io/edit/master/index.html">BE OUR FIRST SPEAKER</a></div>
+          
+          <small>Views and joins in the Mongo shell</small>
+          <div><a href="https://twitter.com/justinjmoses">Justin J. Moses</a></div>
         </li>
         <li class="ride"></li>
         <li class="speaker">


### PR DESCRIPTION
Presentation of a MongoDB shell extension that allows for virtual collections (think SQL Views) that persist queries, projections and inner joins, exposing them as cursors for full extensibility. This utility is particularly handy for anyone who often finds themselves querying mongo in the shell and manually cross-referencing data. https://github.com/mongodb-js/mongo-views