### PR TITLE
Fix broken links

### DIFF
--- a/attendee-faq.md
+++ b/attendee-faq.md
@@ -1,6 +1,6 @@
 # Is BrooklynJS all-ages?
 
-Yes! Our venue 61Local is an all-ages establishment and so is BrooklynJS.
+Yes! Our venue, 61Local, is an all-ages establishment and so is BrooklynJS.
 
 # What is Boroughgramming?
 
@@ -13,8 +13,8 @@ as an icecream.js session afterwards).
 # What's up with the MetroCards?
 
 Every month we laser cut a BrooklynJS themed MetroCard out of a
-different material. We encourage you to keep this card which lets us
-donate your full entrance fee to ScriptEd. Otherwise you can trade in
+different material. We encourage you to keep this card (which lets us
+donate your full entrance fee to ScriptEd). Otherwise you can trade in
 your token for a beverage of your choice (tip your bartender!)
 
 # Are there non-alcoholic beverages? Food?
@@ -30,8 +30,8 @@ downstairs.
 
 # You sell out so fast! Why don't you release more tickets?
 
-We'd love for everyone who wants to come to be able to attend,
-unfortunately we are already packing people in as tight as we can
+We'd love for everyone who wants to come to be able to attend.
+Unfortunately we are already packing people in as tight as we can
 and we just don't have physical space to accommodate any more
 attendees above what we're selling now.
 

--- a/index.html
+++ b/index.html
@@ -330,7 +330,7 @@
       </ol>
     </article>
     <footer>
-      BrooklynJS expects all speakers and attendees<br>to follow the <a href="//jsconf.com/codeofconduct.html">JSConf code of conduct</a>. For more information about us, see our FAQs for <a href="//github.com/brooklynjs/brooklynjs.github.io/blob/master/speakers.md">speakers</a>, <a href="//github.com/brooklynjs/brooklynjs.github.io/blob/master/attendee-faq.md">attendees</a>, and <a href="sponsorship.html">sponsors</a>, or <a href="https://github.com/jed/building-brooklynjs">learn more about our history</a>.
+      BrooklynJS expects all speakers and attendees<br>to follow the <a href="//jsconf.com/codeofconduct.html">JSConf code of conduct</a>. For more information about us, see our FAQs for <a href="https://github.com/brooklynjs/brooklynjs.github.io/blob/master/speakers.md">speakers</a>, <a href="https://github.com/brooklynjs/brooklynjs.github.io/blob/master/attendee-faq.md">attendees</a>, and <a href="sponsorship.html">sponsors</a>, or <a href="https://github.com/jed/building-brooklynjs">learn more about our history</a>.
     </footer>
 
     <script>

--- a/index.html
+++ b/index.html
@@ -330,7 +330,7 @@
       </ol>
     </article>
     <footer>
-      BrooklynJS expects all speakers and attendees<br>to follow the <a href="//jsconf.com/codeofconduct.html">JSConf code of conduct</a>. For more information about us, see our FAQs for <a href="blob/master/speakers.md">speakers</a>, <a href="blob/master/attendee-faq.md">attendees</a>, and <a href="sponsorship.html">sponsors</a>, or <a href="https://github.com/jed/building-brooklynjs">learn more about our history</a>.
+      BrooklynJS expects all speakers and attendees<br>to follow the <a href="//jsconf.com/codeofconduct.html">JSConf code of conduct</a>. For more information about us, see our FAQs for <a href="//github.com/brooklynjs/brooklynjs.github.io/blob/master/speakers.md">speakers</a>, <a href="//github.com/brooklynjs/brooklynjs.github.io/blob/master/attendee-faq.md">attendees</a>, and <a href="sponsorship.html">sponsors</a>, or <a href="https://github.com/jed/building-brooklynjs">learn more about our history</a>.
     </footer>
 
     <script>

--- a/speakers.md
+++ b/speakers.md
@@ -1,29 +1,26 @@
-# Submitting Talk
+# Submitting A Talk
 
-## Who can submit talks to BrooklynJS
-We welcome & encourage _everyone_ to submit talk!
-Whether you have been writing JavaScript for 20 years or few days, experienced or 1st time* speaker, we want to hear that you are excited about.
+## Who can submit talks to BrooklynJS?
+We welcome & encourage _everyone_ to submit a talk!
+Whether you have been writing JavaScript for 20 years or a few days, experienced or 1st time* speaker, we want to hear what you are excited about.
 
-*Our speaker alumni includes Jenna Zeigen (@zeigenvector), Drew Peterson (@KirbySaysHi), Sarah Saltrick Meyer (@meyerini), Byron Hulcher (@hypirlink) & many more who gave their 1st talk at BrooklynJS then started speaking at different meetups and conferences. If you have never spoken before we would love you to submit talk!
+*Our speaker alumni include Jenna Zeigen (@zeigenvector), Drew Peterson (@KirbySaysHi), Sarah Saltrick Meyer (@meyerini), Byron Hulcher (@hypirlink) & many more who gave their 1st talk at BrooklynJS then started speaking at different meetups and conferences. If you have never spoken before we would love for you to submit a talk!
 
-## How Do I submit talks ?
-(TBD on workflow)
+## How do I submit talks ?
+Just submit a pull request to this repository. Modify the schedule in `index.html` to include your talk.
 
-## What would be a good talk topics?
-(TBD on workfrok)
-
-## What do Speakers get?
+## What do speakers get?
 - 1 Boroughgramming* ticket (Free) for you to attend
-- 1 regular BrooklynJS ticket ($15) so your guest don't have to hassle to get ticket
+- 1 regular BrooklynJS ticket ($15) so your guest doesn't have to hassle to get a ticket
 - 10 min to present what you are excited about in front of 100 borough-mates
 - (travel assistance for out of town speakers**)
 
 *If you'd like to come co-work with 30 of borough-mates with bottomless coffee and catered lunch, please be our guest! (We start at 10AM at the same space we run BrooklynJS)
 
-**If you are visiting us from outside of NYC metro area, we provide upto $150 in travel assistance.
+**If you are visiting us from outside of NYC metro area, we provide up to $150 in travel assistance.
 
 ## I have more questions about submitting talks, what should I do?
-Please feel free to ping us on twitter @kosamari @willmanduffy @brianloveswords @jedschmidt or email us [add email address ?]
+Please feel free to ping us on twitter @kosamari @willmanduffy @brianloveswords @jedschmidt
 
 
 # Speaking at BrooklynJS
@@ -44,8 +41,8 @@ We have...
 - VGA
 - VGA to Thunderbolt adapters (Please bring any adapters if you need special one)
 We can also bring portable speaker if you have audio demo (Please let us know in advance)
-If you have any other needs for your talk, feel free to contact organizers. (@kosamari or @willmanduffy)
+If you have any other needs for your talk, feel free to contact the organizers. (@kosamari or @willmanduffy)
 
 ### Setup
-Once the event starts, we'll have musical guest in between talks. Please come up to front and setup for presentation while they are playing intermission.
+Once the event starts, we'll have a musical guest in between talks. Please come up to front and setup for your presentation while they are playing intermission.
 If you want to test out slides/equipment etc, feel free to do so before the event.

--- a/speakers.md
+++ b/speakers.md
@@ -43,9 +43,9 @@ We have...
 - WiFi
 - VGA
 - VGA to Thunderbolt adapters (Please bring any adapters if you need special one)
-We can also bring portable speaker if you have audio demo (Please let us know in advance)  
+We can also bring portable speaker if you have audio demo (Please let us know in advance)
 If you have any other needs for your talk, feel free to contact organizers. (@kosamari or @willmanduffy)
 
 ### Setup
-Once the event starts, we'll have musical guest in between talks. Please come up to front and setup for presentation while they are playing intermission.  
+Once the event starts, we'll have musical guest in between talks. Please come up to front and setup for presentation while they are playing intermission.
 If you want to test out slides/equipment etc, feel free to do so before the event.


### PR DESCRIPTION
I noticed that the `speakers` and `attendees` links in the website footer are broken. I don't know if this is intentional (if it is, feel free to ignore this and apologies for the hassle!).

This PR does two things:
1) Points the speakers/attendees links to the corresponding markdown on Github (this seems to be what is intended).

2)  Minor editing of the speakers and attendees markdown. 