### PR TITLE
add `process.nextTick` in Browserify: All The Corner Cases

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,8 +139,8 @@
             To add yourself to this slot, change the following two lines
             and add a short description paragraph in the pull request.
           -->
-          <small>Listen to our third speaker, or better yet</small>
-          <div><a href="https://github.com/brooklynjs/brooklynjs.github.io/edit/master/index.html">BE OUR THIRD SPEAKER</a></div>
+          <small>`process.nextTick` in Browserify: All The Corner Cases</small>
+           <div><a href="https://twitter.com/cwmma">Calvin Metcalf</a></div>
         </li>
         <li class="ride"></li>
         <li class="speaker">


### PR DESCRIPTION
shimming the node.js function `process.nextTick` in the browser would seem like a straight forward proposition, but when a module is popular enough there are enough corner cases to challenge straight forward assumptions like 'all functions will complete executing before other code runs' or 'you can cache a function in a local variable' fail to hold true.

In this talk we'll discuss the various corner cases, solutions, and mistaken assumptions I encountered helping maintain the process.nextTick shim for browserify