### PR TITLE
Proposal for 3rd talk: NYC Space/Time Directory

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,8 +132,8 @@
             To add yourself to this slot, change the following two lines
             and add a short description paragraph in the pull request.
           -->
-          <small>Listen to our third speaker, or better yet</small>
-          <div><a href="https://github.com/brooklynjs/brooklynjs.github.io/edit/master/index.html">BE OUR THIRD SPEAKER</a></div>
+          <small>NYC Space/Time Directory</small>
+          <div><a href="https://twitter.com/bertspaan">Bert Spaan</a></div>
         </li>
         <li class="ride"></li>
         <li class="speaker">


### PR DESCRIPTION
# NYC Space/Time Directory

The NYC Space/Time Directory will make urban history accessible through the 
kinds of interactive, location-aware tools used to navigate modern 
cityscapes. It will provide a way for scholars, students, and enthusiasts 
to explore New York City across time periods, and to add their own 
knowledge and expertise. 

Over the past five years The New York Public Library has worked on many 
digitization, crowdsourcing, and digital cartography projects, all aiming 
to make the collection of the New York Public Library more accessible. 

The NYC Space/Time Directory, a two-year project funded by the Knight 
Foundation, will build on top of those efforts, and it will create new 
connections between previously unconnected library collections and data 
sources, allowing people to tell new stories about the history of New York 
City. 

# Links

- http://spacetime.nypl.org
- https://github.com/nypl-spacetime
- https://www.meetup.com/historical-data-and-maps-at-nypl/