### PR TITLE
fix CoC page header

### DIFF
--- a/assets/styles/coc.css
+++ b/assets/styles/coc.css
@@ -2,6 +2,13 @@ body {
   font-size: 125%;
 }
 
+
+header {
+  margin: 20px auto;
+  text-align: left;
+  border-top: 4px solid #FFF;
+}
+
 h3 {
   font-weight: 500;
   text-align: center;


### PR DESCRIPTION
Fix header on brooklynjs.com/coc

before:
![screen shot 2017-09-08 at 4 55 56 pm](https://user-images.githubusercontent.com/938722/30230950-aaecb04c-94b6-11e7-8a83-2e4567519c78.png)

after:
![screen shot 2017-09-08 at 4 54 55 pm](https://user-images.githubusercontent.com/938722/30230958-b9e8f060-94b6-11e7-8591-ba8994e31ed3.png)
