### PR TITLE
Remove Jenn from event staff list

### DIFF
--- a/coc.html
+++ b/coc.html
@@ -56,13 +56,6 @@
         </li>
 
         <li>
-          <a href='https://www.twitter.com/jennschiffer'>
-            <img src='assets/images/jenn.png'>
-            <strong>Jenn</strong>
-          </a>
-        </li>
-
-        <li>
           <a href='https://twitter.com/zeigenvector'>
             <img src='assets/images/jenna.png'>
             <strong>Jenna</strong>


### PR DESCRIPTION
This PR removes Jenn from "Find an Event Staff" list on CoC page.
Thank you Jenn for helping us keep great community for the past 2.5 years🙏