### PR TITLE
Fix link to EmpireJS

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
     <article>
       <p>
         PLANNED SERVICE CHANGE<br>
-        BrooklynJS service is suspended during the month of September due to <a href="empirejs.org">EmpireJS</a>. Service will be restored in October.
+        BrooklynJS service is suspended during the month of September due to <a href="//empirejs.org">EmpireJS</a>. Service will be restored in October.
       </p>
     </article>
     <footer>


### PR DESCRIPTION
Hello, 

I noticed the link to the EmpireJS website was broken; it was linking to http://brooklynjs.com/empirejs.org.