### PR TITLE
Consistent line heights in speaker title/name

### DIFF
--- a/assets/styles/index.css
+++ b/assets/styles/index.css
@@ -59,6 +59,7 @@ ol {
 .speaker {
   position: relative;
   padding-left: 30px;
+  line-height: 1em;
 }
 
 .speaker:before {


### PR DESCRIPTION
Fixes emoji in speaker info and stops not lining up by setting a line height.

Before (Chrome):

![image](https://user-images.githubusercontent.com/607807/47237519-598cc200-d3ad-11e8-8142-0c6d98e00c9b.png)

After (Chrome):

![image](https://user-images.githubusercontent.com/607807/47237533-627d9380-d3ad-11e8-87e5-faef2756c37c.png)

Before (Firefox):

![image](https://user-images.githubusercontent.com/607807/47237580-91940500-d3ad-11e8-8e51-35490370c653.png)

After (Firefox):

![image](https://user-images.githubusercontent.com/607807/47237599-9ce73080-d3ad-11e8-929a-49e40f88012a.png)
